### PR TITLE
Update CORS configuration for new client ports

### DIFF
--- a/MoviesApp.Server/Program.cs
+++ b/MoviesApp.Server/Program.cs
@@ -13,13 +13,17 @@ builder.Services.AddDbContext<MoviesDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 // Add CORS
+var allowedOrigins =
+    builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]?>() ??
+    new[] { "https://localhost:7074", "http://localhost:5195" };
+
 builder.Services.AddCors(options =>
 {
-    options.AddPolicy("AllowBlazorClient", builder =>
+    options.AddPolicy("AllowBlazorClient", policyBuilder =>
     {
-        builder.WithOrigins("https://localhost:7001", "http://localhost:5000")
-               .AllowAnyMethod()
-               .AllowAnyHeader();
+        policyBuilder.WithOrigins(allowedOrigins)
+                     .AllowAnyMethod()
+                     .AllowAnyHeader();
     });
 });
 

--- a/MoviesApp.Server/appsettings.Development.json
+++ b/MoviesApp.Server/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "https://localhost:7074",
+      "http://localhost:5195"
+    ]
   }
 }

--- a/MoviesApp.Server/appsettings.json
+++ b/MoviesApp.Server/appsettings.json
@@ -9,5 +9,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Cors": {
+    "AllowedOrigins": [
+      "https://localhost:7074",
+      "http://localhost:5195"
+    ]
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- allow Blazor client ports `https://localhost:7074` and `http://localhost:5195`
- read allowed origins from configuration files

## Testing
- `dotnet build MoviesApp.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686968021bf8832dbc26691b7327ebc1